### PR TITLE
feat: add multi-platform installer scripts

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,158 @@
+# cj Installer Scripts
+
+This directory contains installation scripts for the cj CSV to JSON converter.
+
+## Quick Install
+
+### macOS and Linux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/iqbqioza/cj/main/cli/install.sh | bash
+```
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/iqbqioza/cj/main/cli/install.ps1 | iex
+```
+
+## Manual Installation
+
+### macOS and Linux
+
+1. Download the script:
+   ```bash
+   curl -O https://raw.githubusercontent.com/iqbqioza/cj/main/cli/install.sh
+   chmod +x install.sh
+   ```
+
+2. Run with options:
+   ```bash
+   # Install latest version
+   ./install.sh
+   
+   # Install specific version
+   ./install.sh --version 0.1.0
+   
+   # Skip PATH setup
+   ./install.sh --skip-path-setup
+   ```
+
+### Windows
+
+1. Download the script:
+   ```powershell
+   Invoke-WebRequest -Uri https://raw.githubusercontent.com/iqbqioza/cj/main/cli/install.ps1 -OutFile install.ps1
+   ```
+
+2. Run with options:
+   ```powershell
+   # Install latest version
+   .\install.ps1
+   
+   # Install specific version
+   .\install.ps1 -Version 0.1.0
+   
+   # Skip PATH setup
+   .\install.ps1 -SkipPathSetup
+   ```
+
+## Installation Details
+
+### Default Installation Location
+
+- **macOS/Linux**: `~/.cj/bin/cj`
+- **Windows**: `%USERPROFILE%\.cj\bin\cj.exe`
+
+### Custom Installation Directory
+
+Set the `CJ_INSTALL` environment variable before running the installer:
+
+```bash
+# macOS/Linux
+export CJ_INSTALL=/usr/local/cj
+curl -fsSL https://raw.githubusercontent.com/iqbqioza/cj/main/cli/install.sh | bash
+
+# Windows
+$env:CJ_INSTALL = "C:\Program Files\cj"
+irm https://raw.githubusercontent.com/iqbqioza/cj/main/cli/install.ps1 | iex
+```
+
+### PATH Configuration
+
+The installer will offer to automatically add cj to your PATH by modifying:
+- **bash**: `~/.bashrc`
+- **zsh**: `~/.zshrc`
+- **fish**: `~/.config/fish/config.fish`
+- **Windows**: User environment variable
+
+## Supported Platforms
+
+The installer automatically detects and downloads the appropriate binary for:
+
+### Operating Systems
+- macOS (Darwin)
+- Linux
+- Windows
+
+### Architectures
+- x86_64 / amd64
+- arm64 / aarch64
+- i386 (Windows only)
+
+## Uninstallation
+
+To uninstall cj:
+
+1. Remove the installation directory:
+   ```bash
+   # macOS/Linux
+   rm -rf ~/.cj
+   
+   # Windows
+   Remove-Item -Recurse -Force "$env:USERPROFILE\.cj"
+   ```
+
+2. Remove PATH entry from your shell configuration file
+
+## Troubleshooting
+
+### Permission Denied
+
+If you get a permission error on macOS/Linux:
+```bash
+chmod +x ~/.cj/bin/cj
+```
+
+### Command Not Found
+
+If `cj` is not found after installation:
+1. Restart your terminal, or
+2. Source your shell configuration:
+   ```bash
+   source ~/.bashrc  # for bash
+   source ~/.zshrc   # for zsh
+   ```
+
+### Windows Security Warning
+
+Windows may show a security warning when downloading. To bypass:
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+```
+
+## Development
+
+To test the installer locally:
+
+```bash
+# macOS/Linux
+./install.sh --version 0.1.0
+
+# Windows
+.\install.ps1 -Version 0.1.0
+```
+
+## License
+
+These installation scripts are part of the cj project and are licensed under the MIT License.

--- a/cli/install.ps1
+++ b/cli/install.ps1
@@ -1,0 +1,220 @@
+# cj installer script for Windows
+# PowerShell version
+
+param(
+    [string]$Version = "",
+    [switch]$SkipPathSetup = $false,
+    [switch]$Help = $false
+)
+
+# Configuration
+$GITHUB_REPO = "iqbqioza/cj"
+$INSTALL_DIR = if ($env:CJ_INSTALL) { $env:CJ_INSTALL } else { "$env:USERPROFILE\.cj" }
+$BIN_DIR = "$INSTALL_DIR\bin"
+$BINARY_NAME = "cj.exe"
+$ErrorActionPreference = "Stop"
+
+# Colors
+function Write-ColorOutput($ForegroundColor) {
+    $fc = $host.UI.RawUI.ForegroundColor
+    $host.UI.RawUI.ForegroundColor = $ForegroundColor
+    if ($args) {
+        Write-Output $args
+    }
+    $host.UI.RawUI.ForegroundColor = $fc
+}
+
+function Write-Error-Custom {
+    Write-ColorOutput Red "error: $args"
+    exit 1
+}
+
+function Write-Info {
+    Write-ColorOutput Cyan "info: $args"
+}
+
+function Write-Success {
+    Write-ColorOutput Green "success: $args"
+}
+
+function Write-Warning {
+    Write-ColorOutput Yellow "warning: $args"
+}
+
+# Show help
+if ($Help) {
+    Write-Host "cj installer for Windows"
+    Write-Host ""
+    Write-Host "Usage: .\install.ps1 [OPTIONS]"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -Version VERSION     Install specific version (default: latest)"
+    Write-Host "  -SkipPathSetup       Skip PATH configuration"
+    Write-Host "  -Help                Show this help message"
+    exit 0
+}
+
+Write-Host "cj installer" -ForegroundColor Cyan
+Write-Host "Installing cj - CSV to JSON converter`n"
+
+# Detect architecture
+function Get-Architecture {
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    switch ($arch) {
+        "AMD64" { return "amd64" }
+        "x86" { return "i386" }
+        "ARM64" { return "arm64" }
+        default { Write-Error-Custom "Unsupported architecture: $arch" }
+    }
+}
+
+# Get latest version
+function Get-LatestVersion {
+    try {
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$GITHUB_REPO/releases/latest"
+        $version = $release.tag_name -replace '^v', ''
+        return $version
+    }
+    catch {
+        Write-Error-Custom "Failed to fetch latest version: $_"
+    }
+}
+
+# Download binary
+function Download-Binary {
+    param(
+        [string]$Version,
+        [string]$Architecture
+    )
+    
+    $binaryName = "cj-windows-$Architecture.exe"
+    $downloadUrl = "https://github.com/$GITHUB_REPO/releases/download/v$Version/$binaryName"
+    $tempFile = [System.IO.Path]::GetTempFileName()
+    
+    Write-Info "Downloading cj v$Version for windows-$Architecture..."
+    Write-Info "From: $downloadUrl"
+    
+    try {
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile -UseBasicParsing
+        return $tempFile
+    }
+    catch {
+        Remove-Item -Path $tempFile -ErrorAction SilentlyContinue
+        Write-Error-Custom "Failed to download cj binary: $_"
+    }
+}
+
+# Install binary
+function Install-Binary {
+    param(
+        [string]$BinaryPath
+    )
+    
+    # Create directory
+    if (!(Test-Path $BIN_DIR)) {
+        New-Item -ItemType Directory -Path $BIN_DIR -Force | Out-Null
+    }
+    
+    $targetPath = "$BIN_DIR\$BINARY_NAME"
+    
+    # Copy binary
+    Copy-Item -Path $BinaryPath -Destination $targetPath -Force
+    
+    Write-Success "Installed cj to $targetPath"
+}
+
+# Configure PATH
+function Configure-Path {
+    if ($SkipPathSetup) {
+        return
+    }
+    
+    # Check if already in PATH
+    $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($currentPath -like "*$BIN_DIR*") {
+        Write-Info "PATH already contains $BIN_DIR"
+        return
+    }
+    
+    Write-Host "`nWould you like to add cj to your PATH automatically?" -ForegroundColor Yellow
+    Write-Host "This will add: $BIN_DIR"
+    $response = Read-Host "Proceed? (y/N)"
+    
+    if ($response -match "^[Yy]$") {
+        $newPath = "$BIN_DIR;$currentPath"
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        Write-Success "Added cj to PATH"
+        Write-Host "`nTo start using cj in new terminals, they will automatically have the updated PATH." -ForegroundColor Green
+        Write-Host "For the current terminal, run:" -ForegroundColor Green
+        Write-Host "  `$env:Path = `"$BIN_DIR;`$env:Path`""
+    }
+    else {
+        Write-Host "`nTo manually add cj to your PATH:" -ForegroundColor Yellow
+        Write-Host "  1. Open System Properties > Environment Variables"
+        Write-Host "  2. Edit the 'Path' variable for your user"
+        Write-Host "  3. Add: $BIN_DIR"
+    }
+}
+
+# Verify installation
+function Verify-Installation {
+    $testPath = "$BIN_DIR\$BINARY_NAME"
+    
+    if (!(Test-Path $testPath)) {
+        Write-Error-Custom "Binary not found at $testPath"
+    }
+    
+    try {
+        $output = & $testPath version 2>&1
+        if ($output -match '(\d+\.\d+\.\d+)') {
+            $installedVersion = $matches[1]
+            Write-Success "cj v$installedVersion installed successfully!"
+        }
+        else {
+            Write-Warning "Binary installed but version check failed"
+        }
+    }
+    catch {
+        Write-Warning "Binary installed but could not verify: $_"
+    }
+}
+
+# Main installation
+try {
+    # Get architecture
+    $architecture = Get-Architecture
+    Write-Info "Detected architecture: windows-$architecture"
+    
+    # Get version
+    if ([string]::IsNullOrEmpty($Version)) {
+        $Version = Get-LatestVersion
+        Write-Info "Latest version: v$Version"
+    }
+    else {
+        Write-Info "Installing specified version: v$Version"
+    }
+    
+    # Download binary
+    $tempBinary = Download-Binary -Version $Version -Architecture $architecture
+    
+    # Install binary
+    Install-Binary -BinaryPath $tempBinary
+    
+    # Cleanup
+    Remove-Item -Path $tempBinary -ErrorAction SilentlyContinue
+    
+    # Configure PATH
+    Configure-Path
+    
+    # Verify installation
+    Verify-Installation
+    
+    Write-Host "`nNext steps:" -ForegroundColor Cyan
+    Write-Host "  • Run 'cj --help' to see available commands"
+    Write-Host "  • Visit https://github.com/$GITHUB_REPO for documentation"
+    Write-Host "  • Report issues at https://github.com/$GITHUB_REPO/issues"
+}
+catch {
+    Write-Error-Custom $_
+}

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# cj installer script
+# Based on the Bun installer pattern but adapted for cj
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Configuration
+GITHUB_REPO="iqbqioza/cj"
+INSTALL_DIR="${CJ_INSTALL:-$HOME/.cj}"
+BIN_DIR="$INSTALL_DIR/bin"
+BINARY_NAME="cj"
+
+# Helper functions
+error() {
+    echo -e "${RED}error${RESET}: $1" >&2
+    exit 1
+}
+
+info() {
+    echo -e "${BLUE}info${RESET}: $1"
+}
+
+success() {
+    echo -e "${GREEN}success${RESET}: $1"
+}
+
+warning() {
+    echo -e "${YELLOW}warning${RESET}: $1"
+}
+
+# Detect platform
+detect_platform() {
+    local os
+    local arch
+    local platform
+
+    # Detect OS
+    case "$(uname -s)" in
+        Darwin)
+            os="darwin"
+            ;;
+        Linux)
+            os="linux"
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            os="windows"
+            ;;
+        *)
+            error "Unsupported operating system: $(uname -s)"
+            ;;
+    esac
+
+    # Detect architecture
+    case "$(uname -m)" in
+        x86_64|amd64)
+            arch="amd64"
+            ;;
+        arm64|aarch64)
+            arch="arm64"
+            ;;
+        i386|i686)
+            arch="i386"
+            ;;
+        *)
+            error "Unsupported architecture: $(uname -m)"
+            ;;
+    esac
+
+    # Special case for macOS Rosetta 2
+    if [[ "$os" == "darwin" && "$arch" == "amd64" ]]; then
+        if [[ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" == "1" ]]; then
+            warning "Running on Apple Silicon under Rosetta 2 emulation"
+            warning "Consider using native arm64 build for better performance"
+        fi
+    fi
+
+    platform="${os}-${arch}"
+    echo "$platform"
+}
+
+# Get latest release version
+get_latest_version() {
+    local version
+    version=$(curl -s "https://api.github.com/repos/$GITHUB_REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v?([^"]+)".*/\1/')
+    
+    if [[ -z "$version" ]]; then
+        error "Failed to fetch latest version"
+    fi
+    
+    echo "$version"
+}
+
+# Download binary
+download_binary() {
+    local version="$1"
+    local platform="$2"
+    local binary_name="cj-${platform}"
+    
+    # Add .exe extension for Windows
+    if [[ "$platform" == windows-* ]]; then
+        binary_name="${binary_name}.exe"
+    fi
+    
+    local download_url="https://github.com/$GITHUB_REPO/releases/download/v${version}/${binary_name}"
+    local temp_file="$(mktemp)"
+    
+    info "Downloading cj v${version} for ${platform}..."
+    info "From: $download_url"
+    
+    if ! curl -fsSL "$download_url" -o "$temp_file"; then
+        rm -f "$temp_file"
+        error "Failed to download cj binary"
+    fi
+    
+    echo "$temp_file"
+}
+
+# Install binary
+install_binary() {
+    local binary_path="$1"
+    local target_path="$BIN_DIR/$BINARY_NAME"
+    
+    # Create directory
+    mkdir -p "$BIN_DIR"
+    
+    # Copy binary
+    cp "$binary_path" "$target_path"
+    chmod +x "$target_path"
+    
+    success "Installed cj to $target_path"
+}
+
+# Configure shell
+configure_shell() {
+    local shell_name="$(basename "$SHELL")"
+    local config_file
+    local export_string="export PATH=\"$BIN_DIR:\$PATH\""
+    
+    case "$shell_name" in
+        bash)
+            config_file="$HOME/.bashrc"
+            ;;
+        zsh)
+            config_file="$HOME/.zshrc"
+            ;;
+        fish)
+            config_file="$HOME/.config/fish/config.fish"
+            export_string="set -gx PATH \"$BIN_DIR\" \$PATH"
+            ;;
+        *)
+            warning "Unknown shell: $shell_name"
+            warning "Please manually add $BIN_DIR to your PATH"
+            return
+            ;;
+    esac
+    
+    # Check if PATH is already configured
+    if [[ -f "$config_file" ]] && grep -q "$BIN_DIR" "$config_file"; then
+        info "PATH already configured in $config_file"
+        return
+    fi
+    
+    # Ask user before modifying shell config
+    echo -e "\n${BOLD}Would you like to add cj to your PATH automatically?${RESET}"
+    echo -e "This will add the following line to $config_file:"
+    echo -e "  $export_string"
+    echo -n "Proceed? (y/N) "
+    read -r response
+    
+    if [[ "$response" =~ ^[Yy]$ ]]; then
+        echo "" >> "$config_file"
+        echo "# Added by cj installer" >> "$config_file"
+        echo "$export_string" >> "$config_file"
+        success "Added cj to PATH in $config_file"
+        echo -e "\n${BOLD}To start using cj, run:${RESET}"
+        echo -e "  source $config_file"
+    else
+        echo -e "\n${BOLD}To manually add cj to your PATH, add this to your shell config:${RESET}"
+        echo -e "  $export_string"
+    fi
+}
+
+# Verify installation
+verify_installation() {
+    local test_path="$BIN_DIR/$BINARY_NAME"
+    
+    if [[ ! -f "$test_path" ]]; then
+        error "Binary not found at $test_path"
+    fi
+    
+    if [[ ! -x "$test_path" ]]; then
+        error "Binary is not executable"
+    fi
+    
+    # Try to run version command
+    if "$test_path" version &>/dev/null; then
+        local version=$("$test_path" version 2>&1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)
+        success "cj v${version} installed successfully!"
+    else
+        warning "Binary installed but version check failed"
+    fi
+}
+
+# Main installation flow
+main() {
+    echo -e "${BOLD}cj installer${RESET}"
+    echo -e "Installing cj - CSV to JSON converter\n"
+    
+    # Parse arguments
+    local version=""
+    local skip_path_setup=false
+    
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --version)
+                version="$2"
+                shift 2
+                ;;
+            --skip-path-setup)
+                skip_path_setup=true
+                shift
+                ;;
+            --help)
+                echo "Usage: $0 [OPTIONS]"
+                echo ""
+                echo "Options:"
+                echo "  --version VERSION    Install specific version (default: latest)"
+                echo "  --skip-path-setup    Skip PATH configuration"
+                echo "  --help               Show this help message"
+                exit 0
+                ;;
+            *)
+                error "Unknown option: $1"
+                ;;
+        esac
+    done
+    
+    # Check dependencies
+    if ! command -v curl &> /dev/null; then
+        error "curl is required but not installed"
+    fi
+    
+    # Detect platform
+    local platform
+    platform=$(detect_platform)
+    info "Detected platform: $platform"
+    
+    # Get version
+    if [[ -z "$version" ]]; then
+        version=$(get_latest_version)
+        info "Latest version: v$version"
+    else
+        info "Installing specified version: v$version"
+    fi
+    
+    # Download binary
+    local temp_binary
+    temp_binary=$(download_binary "$version" "$platform")
+    
+    # Install binary
+    install_binary "$temp_binary"
+    
+    # Cleanup
+    rm -f "$temp_binary"
+    
+    # Configure shell PATH
+    if [[ "$skip_path_setup" != true ]]; then
+        configure_shell
+    fi
+    
+    # Verify installation
+    verify_installation
+    
+    echo -e "\n${BOLD}Next steps:${RESET}"
+    echo -e "  • Run 'cj --help' to see available commands"
+    echo -e "  • Visit https://github.com/$GITHUB_REPO for documentation"
+    echo -e "  • Report issues at https://github.com/$GITHUB_REPO/issues"
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## Summary
- Add cross-platform installer scripts for easy cj installation
- Support one-line installation commands for all major platforms

## What's New
### 🚀 Quick Install Commands
- **macOS/Linux**: `curl -fsSL https://raw.githubusercontent.com/iqbqioza/cj/main/cli/install.sh | bash`
- **Windows**: `irm https://raw.githubusercontent.com/iqbqioza/cj/main/cli/install.ps1 | iex`

### 📁 Files Added
- `cli/install.sh` - Bash installer for macOS/Linux
- `cli/install.ps1` - PowerShell installer for Windows  
- `cli/README.md` - Comprehensive installation guide

## Features
### Platform Detection
- ✅ Automatic OS detection (macOS, Linux, Windows)
- ✅ Architecture detection (x86_64, arm64, i386)
- ✅ Special handling for Apple Silicon Rosetta 2

### Installation Process
- ✅ Downloads from GitHub Releases
- ✅ Installs to `~/.cj/bin` (customizable via `CJ_INSTALL`)
- ✅ Automatic PATH configuration with user confirmation
- ✅ Shell-specific configuration (bash, zsh, fish, PowerShell)

### User Experience
- ✅ Colored output for better readability
- ✅ Clear error messages and warnings
- ✅ Version selection support
- ✅ Post-installation verification
- ✅ Helpful next steps guidance

## Test Plan
- [x] Tested `--help` flag locally
- [x] Script syntax validation
- [ ] Test on macOS (arm64/x86_64)
- [ ] Test on Linux (x86_64/arm64)
- [ ] Test on Windows (PowerShell)

## Implementation Notes
- Based on Bun's installer pattern but adapted for cj
- Follows shell scripting best practices (`set -euo pipefail`)
- Comprehensive error handling
- No external dependencies except curl (macOS/Linux)

## Future Enhancements
- Add support for system-wide installation
- Package manager integrations (Homebrew, apt, chocolatey)
- Automatic updates functionality